### PR TITLE
 Added .gitignore for Java project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Ignore compiled Java files
+*.class
+
+# Ignore IntelliJ/IDEA and VS Code settings
+.idea/
+.vscode/
+
+# Ignore output folders
+out/
+bin/
+
+# Ignore other temp/log files
+*.log


### PR DESCRIPTION
Added a .gitignore file to exclude compiled Java files, IDE-specific settings, output directories, and temporary/log files. This will help keep the repository clean by preventing unnecessary files from being tracked.